### PR TITLE
Fix #2 (Color.fromString failing when ExtendedColor is required) 

### DIFF
--- a/Color.js
+++ b/Color.js
@@ -326,7 +326,7 @@ define(["dcl/dcl"], function (dcl) {
 		// returns:
 		//		A dojo.Color object. If obj is passed, it will be the return value.
 		var a = Color.named[str];
-		return a && (Color.fromHex(a, obj) ||  Color.fromRgbaArray(a, obj)) ||
+		return a && ((typeof a === "string" && Color.fromHex(a, obj)) ||  Color.fromRgbaArray(a, obj)) ||
 			Color.fromRgbaString(str, obj) || Color.fromHslaString(str, obj) || Color.fromHex(str, obj);
 	};
 

--- a/tests/ExtendedColor.js
+++ b/tests/ExtendedColor.js
@@ -1,0 +1,26 @@
+define([
+	"intern!object",
+	"intern/chai!assert",
+	"../Color",
+	"../ExtendedColor"
+], function (registerSuite, assert, Color) {
+	var verifyColor = function (source, expected) {
+		var color = new Color(source);
+		assert.deepEqual(color.toRgbaArray(), expected);
+		color.toRgbaArray().forEach(function (n) {
+			assert.typeOf(n, "number");
+		});
+	};
+	registerSuite({
+		name: "ExtendedColor",
+		"extended aliceblue": function () {
+			verifyColor("aliceblue", [240, 248, 255, 1]);
+		},
+		"extended orange": function () {
+			verifyColor("orange", [255, 165, 0, 1]);
+		},
+		"extended yellowgreen": function () {
+			verifyColor("yellowgreen", [154, 205, 50, 1]);
+		}
+	});
+});

--- a/tests/all.js
+++ b/tests/all.js
@@ -2,5 +2,6 @@
 define([
 	"./ColorModel",
 	"./utils",
-	"./Color"
+	"./Color",
+	"./ExtendedColor"
 ]);


### PR DESCRIPTION
The fix is an addition of a test to check if the named color is a string before calling fromHex.
